### PR TITLE
Unit test refactors

### DIFF
--- a/PackageTracker/PackageTracker.xcodeproj/project.pbxproj
+++ b/PackageTracker/PackageTracker.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		55476F611AFFD5ED00F9003C /* Info.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55476F601AFFD5ED00F9003C /* Info.swift */; };
 		55476F671AFFED4B00F9003C /* TestInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55476F661AFFED4B00F9003C /* TestInfo.swift */; };
 		84F91D511C0A2326005FBFCE /* PackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F91D501C0A2326005FBFCE /* PackageManager.swift */; };
+		84F91D531C0A246B005FBFCE /* MockPackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F91D521C0A246B005FBFCE /* MockPackageManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 		55476F601AFFD5ED00F9003C /* Info.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Info.swift; sourceTree = "<group>"; };
 		55476F661AFFED4B00F9003C /* TestInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInfo.swift; sourceTree = "<group>"; };
 		84F91D501C0A2326005FBFCE /* PackageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PackageManager.swift; sourceTree = "<group>"; };
+		84F91D521C0A246B005FBFCE /* MockPackageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPackageManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +161,7 @@
 				20182FF71B1364B4002824F4 /* USPSRequestFlow.swift */,
 				20C269611BA510AD0044FCA9 /* ViewControllerTests.swift */,
 				20C269651BA60B1B0044FCA9 /* TrackingHistoryViewControllerTests.swift */,
+				84F91D521C0A246B005FBFCE /* MockPackageManager.swift */,
 			);
 			path = PackageTrackerTests;
 			sourceTree = "<group>";
@@ -312,6 +315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84F91D531C0A246B005FBFCE /* MockPackageManager.swift in Sources */,
 				20C269621BA510AD0044FCA9 /* ViewControllerTests.swift in Sources */,
 				20182FF81B1364B4002824F4 /* USPSRequestFlow.swift in Sources */,
 				207D4D3E1BD67AAB006FAB09 /* PadSplitViewControllerTests.swift in Sources */,

--- a/PackageTracker/PackageTracker.xcodeproj/project.pbxproj
+++ b/PackageTracker/PackageTracker.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		55476F5E1AFFD57300F9003C /* Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55476F5D1AFFD57300F9003C /* Detail.swift */; };
 		55476F611AFFD5ED00F9003C /* Info.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55476F601AFFD5ED00F9003C /* Info.swift */; };
 		55476F671AFFED4B00F9003C /* TestInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55476F661AFFED4B00F9003C /* TestInfo.swift */; };
+		84F91D511C0A2326005FBFCE /* PackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F91D501C0A2326005FBFCE /* PackageManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		55476F5D1AFFD57300F9003C /* Detail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Detail.swift; sourceTree = "<group>"; };
 		55476F601AFFD5ED00F9003C /* Info.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Info.swift; sourceTree = "<group>"; };
 		55476F661AFFED4B00F9003C /* TestInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInfo.swift; sourceTree = "<group>"; };
+		84F91D501C0A2326005FBFCE /* PackageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PackageManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +126,7 @@
 				2092AAF01B68613E005DBC46 /* PersistenceController.swift */,
 				205EF4B71B2DF6CA0019FE77 /* USPSCommunicator.swift */,
 				2029545A1B3119A400F96975 /* USPSManager.swift */,
+				84F91D501C0A2326005FBFCE /* PackageManager.swift */,
 				55476F591AFFD2E200F9003C /* Model */,
 				20182FF91B1365F0002824F4 /* USPSRequestInfo.swift */,
 				20DE6D881AED687E00A7A73F /* AppDelegate.swift */,
@@ -285,6 +288,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84F91D511C0A2326005FBFCE /* PackageManager.swift in Sources */,
 				2092AB201B6873F1005DBC46 /* Package+CoreDataProperties.swift in Sources */,
 				20182FFA1B1365F0002824F4 /* USPSRequestInfo.swift in Sources */,
 				55476F5E1AFFD57300F9003C /* Detail.swift in Sources */,

--- a/PackageTracker/PackageTracker/AppDelegate.swift
+++ b/PackageTracker/PackageTracker/AppDelegate.swift
@@ -15,7 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-        // Override point for customization after application launch.
         let splitViewController = window!.rootViewController as! UISplitViewController
         let navController = splitViewController.viewControllers.last as! UINavigationController
         navController.topViewController?.navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem()
@@ -23,36 +22,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(application: UIApplication) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
     func splitViewController(splitViewController: UISplitViewController, collapseSecondaryViewController secondaryViewController:UIViewController, ontoPrimaryViewController primaryViewController:UIViewController) -> Bool {
         guard let secondaryAsNavController = secondaryViewController as? UINavigationController else { return false }
-        guard let topAsDetailController = secondaryAsNavController.topViewController as? ViewController else { return false }
-//        if topAsDetailController.detailItem == nil {
-            // Return true to indicate that we have handled the collapse by doing nothing; the secondary controller will be discarded.
+        guard let _ = secondaryAsNavController.topViewController as? ViewController else { return false }
             return true
-//        }
-//        return false
     }
 }
 

--- a/PackageTracker/PackageTracker/PackageManager.swift
+++ b/PackageTracker/PackageTracker/PackageManager.swift
@@ -1,0 +1,11 @@
+//
+//  PackageManager.swift
+//  PackageTracker
+//
+//  Created by Joe Masilotti on 11/28/15.
+//  Copyright © 2015 Concepts In Code. All rights reserved.
+//
+
+protocol PackageManager {
+    static func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?)
+}

--- a/PackageTracker/PackageTracker/PackageManager.swift
+++ b/PackageTracker/PackageTracker/PackageManager.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Concepts In Code. All rights reserved.
 //
 
+typealias PackageCompletion = ([String]) -> Void
+
 protocol PackageManager {
-    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?)
+    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: PackageCompletion?)
 }

--- a/PackageTracker/PackageTracker/PackageManager.swift
+++ b/PackageTracker/PackageTracker/PackageManager.swift
@@ -7,5 +7,5 @@
 //
 
 protocol PackageManager {
-    static func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?)
+    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?)
 }

--- a/PackageTracker/PackageTracker/TrackingHistoryViewController.swift
+++ b/PackageTracker/PackageTracker/TrackingHistoryViewController.swift
@@ -37,12 +37,10 @@ class TrackingHistoryViewController: UIViewController {
     
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-//        NSNotificationCenter.defaultCenter().addObserver(self, selector: "fetchAndDisplayHistory", name: "CoreDataReady", object: nil)
         NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("fetchAndDisplayHistory"), name: "core data stack created", object: nil)
     }
     
     override func viewWillDisappear(animated: Bool) {
-//        NSNotificationCenter.defaultCenter().removeObserver(self, name: "CoreDataReady", object: nil)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: "core data stack created", object: nil)
     }
     
@@ -75,7 +73,6 @@ class TrackingHistoryViewController: UIViewController {
     // MARK: navigation
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if segue.identifier == "showDetail",
-//            let indexPath = tableView.indexPathForSelectedRow,
             let navVC = segue.destinationViewController as? UINavigationController,
             packageInjectable = navVC.topViewController as? PackageDependencyInjectable {
                 
@@ -109,8 +106,6 @@ extension TrackingHistoryViewController : UITableViewDataSource, UITableViewDele
         performSegueWithIdentifier("showDetail", sender: nil)
     }
 }
-
-//extension TrackingHistoryViewController : PersistenceControllerAccessible { }
 
 protocol PackageDependencyInjectable {
     func updateDetailsForPackageID(packageID: String, completion: Void -> Void)

--- a/PackageTracker/PackageTracker/USPSManager.swift
+++ b/PackageTracker/PackageTracker/USPSManager.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct USPSManager: PackageManager {
     
-    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?) {
+    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: PackageCompletion?) {
         
         USPSCommunicator.fetchPackageResults(requestInfo) { (data) -> Void in
             let xmlParser = NSXMLParser(data: data)

--- a/PackageTracker/PackageTracker/USPSManager.swift
+++ b/PackageTracker/PackageTracker/USPSManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct USPSManager {
+struct USPSManager: PackageManager {
     
     static func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?) {
         

--- a/PackageTracker/PackageTracker/USPSManager.swift
+++ b/PackageTracker/PackageTracker/USPSManager.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct USPSManager: PackageManager {
     
-    static func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?) {
+    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?) {
         
         USPSCommunicator.fetchPackageResults(requestInfo) { (data) -> Void in
             let xmlParser = NSXMLParser(data: data)

--- a/PackageTracker/PackageTracker/ViewController.swift
+++ b/PackageTracker/PackageTracker/ViewController.swift
@@ -11,64 +11,13 @@ import Foundation
 import CoreData
 
 class ViewController: UIViewController, UITableViewDataSource {
-    
 
     var items = [String]()
 
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var trackingTextField: UITextField!
     @IBOutlet weak var trackPackageButton: UIButton!
-//    @IBOutlet weak var showHistoryButton: UIButton!
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-//        showHistoryButton?.setImage(UIImage(named: "disabledClock"), forState: .Disabled)
-//        showHistoryButton?.enabled = false
-//        
-//        let allObjects = persistenceController.fetchAll(entity: "Package")
-//        print("all objects: \(allObjects.count)")
-//        _ = persistenceController // instantiates lazy property
-        
-//        splitViewController?.viewControllers.
-    }
 
-    /*
-    @IBAction func trackPackageTapped(sender: UIButton) {
-        guard let text = trackingTextField.text where !text.isEmpty else { return }
-        
-        trackingTextField.resignFirstResponder()
-        
-        guard let filePath = NSBundle.mainBundle().pathForResource("USPSConfig", ofType: "json") else {
-            let mockRequestInfo = USPSRequestInfo(userID: "steve", packageID: "123")
-            USPSManager.fetchPackageResults(mockRequestInfo) { items in
-                self.items = ["There is nothing to track"]
-                self.tableView.reloadData()
-            }
-            return
-        }
-        let data = NSData(contentsOfFile: filePath)!
-        let json: AnyObject = try! NSJSONSerialization.JSONObjectWithData(data, options: .AllowFragments)
-        let userID = json["userID"] as! String
-        let packageID = trackingTextField.text ?? ""
-        let requestInfo = USPSRequestInfo(userID: userID, packageID: packageID)
-        
-        let workerContext = WorkerContext(parent: persistenceController.mainContext)
-        let package = workerContext.insert("Package") as! Package
-        package.packageID = requestInfo.packageID
-        workerContext.save { () -> Void in
-            print("i saved!")
-        }
-
-        USPSManager.fetchPackageResults(requestInfo) { (items: [String]) -> Void in
-            self.items = items
-            self.tableView.reloadData()
-            self.persistenceController.save()
-            self.postCoreDataReady()
-        }
-    }
-*/
-    
     @IBAction func showHistory(sender: AnyObject?) {
         performSegueWithIdentifier("showHistorySegue", sender: nil)
     }
@@ -92,29 +41,11 @@ class ViewController: UIViewController, UITableViewDataSource {
         cell.textLabel?.text = items[indexPath.row]
         
         return cell
-        
     }
     
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return items.count
     }
-    
-    /*
-    func updateUI(notification: NSNotification) {
-        
-//        let split = splitViewController as? PadSplitViewController
-//        split?.setPersistenceControllerForMasterViewController(persistenceController)
-        
-//        let packages = persistenceController.fetchAll(entity: "Package")
-//        showHistoryButton?.enabled = (packages.count > 0)
-
-//        postCoreDataReady()
-    }
-    */
-    
-//    private func postCoreDataReady() {
-//        NSNotificationCenter.defaultCenter().postNotificationName("CoreDataReady", object: nil)
-//    }
     
     private func userIDFromJSON() -> String? {
         guard let filePath = NSBundle.mainBundle().pathForResource("USPSConfig", ofType: "json") else { return nil }
@@ -123,17 +54,6 @@ class ViewController: UIViewController, UITableViewDataSource {
         let userID = json["userID"] as! String
         return userID
     }
-    
-    /*
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        if segue.identifier == "showHistorySegue", let destinationVC = segue.destinationViewController as? TrackingHistoryViewController {
-            destinationVC.persistenceController = persistenceController
-            destinationVC.handleSelection = { [weak self] packageID in
-                self?.fetchPackageInfo(packageID: packageID)
-            }
-        }
-    }
-    */
     
     func fetchPackageInfo(packageID packageID: String, completion: (Void -> Void)? = nil) {
         guard let userID = userIDFromJSON() else {

--- a/PackageTracker/PackageTracker/ViewController.swift
+++ b/PackageTracker/PackageTracker/ViewController.swift
@@ -62,7 +62,7 @@ class ViewController: UIViewController, UITableViewDataSource {
             return
         }
         let requestInfo = USPSRequestInfo(userID: userID, packageID: packageID)
-        USPSManager.fetchPackageResults(requestInfo) { [weak self] items in
+        USPSManager().fetchPackageResults(requestInfo) { [weak self] items in
             defer { self?.tableView.reloadData() }
             if items.isEmpty {
                 self?.items = ["There's nothing to see here"]

--- a/PackageTracker/PackageTracker/ViewController.swift
+++ b/PackageTracker/PackageTracker/ViewController.swift
@@ -14,6 +14,8 @@ class ViewController: UIViewController, UITableViewDataSource {
 
     var items = [String]()
 
+    internal lazy var packageManager: PackageManager = { USPSManager() }()
+
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var trackingTextField: UITextField!
     @IBOutlet weak var trackPackageButton: UIButton!
@@ -62,7 +64,7 @@ class ViewController: UIViewController, UITableViewDataSource {
             return
         }
         let requestInfo = USPSRequestInfo(userID: userID, packageID: packageID)
-        USPSManager().fetchPackageResults(requestInfo) { [weak self] items in
+        packageManager.fetchPackageResults(requestInfo) { [weak self] items in
             defer { self?.tableView.reloadData() }
             if items.isEmpty {
                 self?.items = ["There's nothing to see here"]

--- a/PackageTracker/PackageTrackerTests/MockPackageManager.swift
+++ b/PackageTracker/PackageTrackerTests/MockPackageManager.swift
@@ -10,8 +10,13 @@
 
 class MockPackageManager: PackageManager {
     var lastRequestInfo: USPSRequestInfo?
+    var nextInfos: [String]?
 
     func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: PackageCompletion?) {
         lastRequestInfo = requestInfo
+
+        if let infos = nextInfos, completion = completionHandler {
+            completion(infos)
+        }
     }
 }

--- a/PackageTracker/PackageTrackerTests/MockPackageManager.swift
+++ b/PackageTracker/PackageTrackerTests/MockPackageManager.swift
@@ -1,0 +1,17 @@
+//
+//  MockPackageManager.swift
+//  PackageTracker
+//
+//  Created by Joe Masilotti on 11/28/15.
+//  Copyright © 2015 Concepts In Code. All rights reserved.
+//
+
+@testable import PackageTracker
+
+class MockPackageManager: PackageManager {
+    var lastRequestInfo: USPSRequestInfo?
+
+    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?) {
+        lastRequestInfo = requestInfo
+    }
+}

--- a/PackageTracker/PackageTrackerTests/MockPackageManager.swift
+++ b/PackageTracker/PackageTrackerTests/MockPackageManager.swift
@@ -11,7 +11,7 @@
 class MockPackageManager: PackageManager {
     var lastRequestInfo: USPSRequestInfo?
 
-    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: (([String]) -> Void)?) {
+    func fetchPackageResults(requestInfo: USPSRequestInfo, completionHandler: PackageCompletion?) {
         lastRequestInfo = requestInfo
     }
 }

--- a/PackageTracker/PackageTrackerTests/PadSplitViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/PadSplitViewControllerTests.swift
@@ -19,7 +19,7 @@ class PadSplitViewControllerTests: XCTestCase {
 
         sut = storyboard.instantiateViewControllerWithIdentifier("PadSplitViewController") as! PadSplitViewController
         UIApplication.sharedApplication().keyWindow!.rootViewController = sut
-        _ = sut.view
+        XCTAssertNotNil(sut.view)
     }
     
     // MARK: test initial state

--- a/PackageTracker/PackageTrackerTests/TestInfo.swift
+++ b/PackageTracker/PackageTrackerTests/TestInfo.swift
@@ -13,17 +13,6 @@ import XCTest
 import PackageTracker
 
 class TestInfo: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
     func testInfoCreation() {
         let xmlString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrackResponse><TrackInfo ID=\"9400116901500000000000\"><TrackSummary><EventTime>1:18 pm</EventTime><EventDate>April 22, 2015</EventDate><Event>Delivered, In/At Mailbox</Event><EventCity>AVON LAKE</EventCity><EventState>OH</EventState><EventZIPCode>44012</EventZIPCode><EventCountry/><FirmName/><Name/><AuthorizedAgent>false</AuthorizedAgent><DeliveryAttributeCode>01</DeliveryAttributeCode></TrackSummary><TrackDetail><EventTime>5:25 am</EventTime><EventDate>April 22, 2015</EventDate><Event>Arrived at Post Office</Event><EventCity>AVON LAKE</EventCity><EventState>OH</EventState><EventZIPCode>44012</EventZIPCode><EventCountry/><FirmName/><Name/><AuthorizedAgent>false</AuthorizedAgent></TrackDetail><TrackDetail><EventTime>10:45 pm</EventTime><EventDate>April 21, 2015</EventDate><Event>Arrived at USPS Facility</Event><EventCity>CLEVELAND</EventCity><EventState>OH</EventState><EventZIPCode>44101</EventZIPCode><EventCountry/><FirmName/><Name/><AuthorizedAgent>false</AuthorizedAgent></TrackDetail></TrackInfo></TrackResponse>"
         

--- a/PackageTracker/PackageTrackerTests/TrackingHistoryViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/TrackingHistoryViewControllerTests.swift
@@ -18,7 +18,7 @@ class TrackingHistoryViewControllerTests: XCTestCase {
         super.setUp()
 
         sut = storyboard.instantiateViewControllerWithIdentifier("TrackingHistoryViewController") as! TrackingHistoryViewController
-        _ = sut.view
+        XCTAssertNotNil(sut.view)
     }
     
     

--- a/PackageTracker/PackageTrackerTests/TrackingHistoryViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/TrackingHistoryViewControllerTests.swift
@@ -47,11 +47,6 @@ class TrackingHistoryViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.items.count, 0)
     }
     
-//    func testPersistenceControllerVariableIsNil() {
-//        XCTAssertNil(sut.persistenceController)
-//    }
-    
-    
     // MARK: test buttons contain actions
     func testTrackPackageButtonAction() {
         let button = sut.trackPackageButton

--- a/PackageTracker/PackageTrackerTests/USPSRequestFlow.swift
+++ b/PackageTracker/PackageTrackerTests/USPSRequestFlow.swift
@@ -81,7 +81,7 @@ class USPSRequestFlow: XCTestCase {
         let request = USPSRequestInfo(userID: userID, packageID: packageID)
         let expectation = expectationWithDescription("testing getting data")
         
-        USPSManager.fetchPackageResults(request) { (items: [String]) -> Void in
+        USPSManager().fetchPackageResults(request) { (items: [String]) -> Void in
             XCTAssertGreaterThan(items.count, 0)
             expectation.fulfill()
         }

--- a/PackageTracker/PackageTrackerTests/USPSRequestInfo.swift
+++ b/PackageTracker/PackageTrackerTests/USPSRequestInfo.swift
@@ -30,3 +30,8 @@ struct USPSRequestInfo {
     }
     
 }
+
+extension USPSRequestInfo: Equatable { }
+func ==(lhs: USPSRequestInfo, rhs: USPSRequestInfo) -> Bool {
+    return lhs.userID == rhs.userID && lhs.packageID == rhs.packageID
+}

--- a/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
@@ -34,4 +34,15 @@ class ViewControllerTests: XCTestCase {
         let requestInfo = USPSRequestInfo(userID: "908SIXFI7346", packageID: "package")
         XCTAssertEqual(packageManager.lastRequestInfo, requestInfo)
     }
+
+    func test_SuccessfulFetch_DisplaysTheResults() {
+        packageManager.nextInfos = ["Departed", "Transferred", "Arrived"]
+
+        sut.fetchPackageInfo(packageID: "package")
+
+        XCTAssertEqual(sut.tableView(sut.tableView, numberOfRowsInSection: 0), 3)
+        let firstIndex = NSIndexPath(forRow: 0, inSection: 0)
+        let firstCell = sut.tableView(sut.tableView, cellForRowAtIndexPath: firstIndex)
+        XCTAssertEqual(firstCell.textLabel?.text, "Departed")
+    }
 }

--- a/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
@@ -21,88 +21,8 @@ class ViewControllerTests: XCTestCase {
         UIApplication.sharedApplication().keyWindow!.rootViewController = sut
         XCTAssertNotNil(sut.view)
     }
-    
 
-    // MARK: test outlets and initial state
-    
-//    func testShowHistoryButtonOutletIsConnected() {
-//        guard case UIUserInterfaceIdiom.Phone = sut.traitCollection.userInterfaceIdiom else {
-//            XCTAssert(true)
-//            return
-//        }
-//        
-//        XCTAssertNotNil(sut.showHistoryButton)
-//    }
-    
-//    func testTrackingTextFieldOutletIsConnected() {
-//        XCTAssertNotNil(sut.trackingTextField)
-//    }
-    
     func testTableViewOutletIsConnected() {
         XCTAssertNotNil(sut.tableView)
     }
-    
-    
-    // MARK: test actions
-//    func testHistoryButtonAction() {
-//        guard case UIUserInterfaceIdiom.Phone = sut.traitCollection.userInterfaceIdiom else {
-//            XCTAssert(true)
-//            return
-//        }
-//        
-//        let button = sut.showHistoryButton
-//        let actions = button.actionsForTarget(sut, forControlEvent: .TouchUpInside) ?? []
-//        XCTAssertTrue(actions.contains("showHistory:"))
-//    }
-    
-//    func testHistoryButtonIsDisabledUponInitialLoad() {
-//        guard case UIUserInterfaceIdiom.Phone = sut.traitCollection.userInterfaceIdiom else {
-//            XCTAssert(true)
-//            return
-//        }
-//        
-//        XCTAssertFalse(sut.showHistoryButton.enabled)
-//    }
-    
-//    func testHistoryButtonImagesForStates() {
-//        guard case UIUserInterfaceIdiom.Phone = sut.traitCollection.userInterfaceIdiom else {
-//            XCTAssert(true)
-//            return
-//        }
-//        
-//        XCTAssertTrue(sut.showHistoryButton.imageForState(.Disabled) == UIImage(named: "disabledClock"))
-//        XCTAssertTrue(sut.showHistoryButton.imageForState(.Normal) == UIImage(named: "clock"))
-//    }
-    
-    
-    // text actions produce results
-//    func testShowHistoryButtonPerformsSegue() {
-//        guard case UIUserInterfaceIdiom.Phone = sut.traitCollection.userInterfaceIdiom else {
-//            XCTAssert(true)
-//            return
-//        }
-//        // when
-//        sut.showHistory(nil)
-//        
-//        // then
-//        if let _ = sut.presentedViewController as? TrackingHistoryViewController {
-//            XCTAssert(true, "presentedViewController should be TrackingHistoryViewController")
-//        } else {
-//            XCTFail("presentedViewController should be TrackingHistoryViewController. \(sut.presentedViewController?.description)")
-//        }
-//    }
-    
-//    func testTrackingHistoryVCGetsPersistenceControllerVariableDependency() {
-//        guard case UIUserInterfaceIdiom.Phone = sut.traitCollection.userInterfaceIdiom else {
-//            XCTAssert(true)
-//            return
-//        }
-//        // when
-//        sut.showHistory(nil)
-//        
-//        // then
-//        guard let trackingVC = sut.presentedViewController as? TrackingHistoryViewController else { XCTFail("tracking vc should not be nil"); return }
-//        XCTAssertNotNil(trackingVC.persistenceController, "persistenceController should not be nil, it should be set in source's prepareForSegue.")
-//    }
-    
 }

--- a/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
@@ -13,11 +13,13 @@ class ViewControllerTests: XCTestCase {
     
     let storyboard = UIStoryboard(name: "Main", bundle: nil)
     var sut: ViewController!
+    let packageManager = MockPackageManager()
     
     override func setUp() {
         super.setUp()
 
         sut = storyboard.instantiateViewControllerWithIdentifier("ViewController") as! ViewController
+        sut.packageManager = packageManager
         UIApplication.sharedApplication().keyWindow!.rootViewController = sut
         XCTAssertNotNil(sut.view)
     }

--- a/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
@@ -27,4 +27,11 @@ class ViewControllerTests: XCTestCase {
     func testTableViewOutletIsConnected() {
         XCTAssertNotNil(sut.tableView)
     }
+
+    func test_OnLoad_FetchesPackageDetails() {
+        sut.fetchPackageInfo(packageID: "package")
+
+        let requestInfo = USPSRequestInfo(userID: "908SIXFI7346", packageID: "package")
+        XCTAssertEqual(packageManager.lastRequestInfo, requestInfo)
+    }
 }

--- a/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
+++ b/PackageTracker/PackageTrackerTests/ViewControllerTests.swift
@@ -19,7 +19,7 @@ class ViewControllerTests: XCTestCase {
 
         sut = storyboard.instantiateViewControllerWithIdentifier("ViewController") as! ViewController
         UIApplication.sharedApplication().keyWindow!.rootViewController = sut
-        _ = sut.view
+        XCTAssertNotNil(sut.view)
     }
     
 

--- a/PackageTracker/PersistenceController.swift
+++ b/PackageTracker/PersistenceController.swift
@@ -113,13 +113,8 @@ public struct WorkerContext {
         }
         
         context.performBlock {
-//            var error: NSError?
-//            let didSave = self.context.save(&error)
             try! self.context.save()
             
-//            if !didSave {
-//                print("error saving worker context. code: \(error?.code ?? 0). error: \(error?.localizedDescription ?? String())")
-//            }
             completion?()
         }
     }


### PR DESCRIPTION
Here's a first pass at making `ViewController` a little more testable. I'm following the techniques I've outlined in [Better Unit Testing with Swift](http://masilotti.com/better-swift-unit-testing/), namely:
- inject static dependencies
- make dependencies protocols
- make all value types equatable

First, I made `USPSManager` conform to a new protocol, `PackageManager`. This allows us to create a mock for use under tests. Then, to make assertions easier, I moved the class methods to instance methods. Now the mock can record each parameter that was passed to it under test (and call the completion block with mock data!).

This required opening up the `packageManager` variable on `ViewController`. Ideally, this would be [a `let` variable and injected via the initializer](http://masilotti.com/better-swift-unit-testing/#set-default-initialized-parameters). However, I wasn't able to get this to work with storyboards so I figured a lazy-evaluated `var` was a good tradeoff.

Finally, the tests set up some mock package tracking information then assert that the table shows said data.
